### PR TITLE
Added Should.Throw assertions that work asynchronously with Tasks

### DIFF
--- a/EasyAssertions/EasyAssertions.csproj
+++ b/EasyAssertions/EasyAssertions.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>EasyAssertions</RootNamespace>
     <AssemblyName>EasyAssertions</AssemblyName>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SccProjectName>
     </SccProjectName>
@@ -30,6 +30,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -39,6 +40,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Release\EasyAssertions.xml</DocumentationFile>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup>
     <SignAssembly>true</SignAssembly>

--- a/UnitTests/Assertions/AsyncFunctionAssertionTests.cs
+++ b/UnitTests/Assertions/AsyncFunctionAssertionTests.cs
@@ -1,0 +1,99 @@
+﻿using System;
+using System.Linq.Expressions;
+using NSubstitute;
+using NUnit.Framework;
+using System.Threading.Tasks;
+
+namespace EasyAssertions.UnitTests
+{
+    [TestFixture]
+    public class AsyncFunctionAssertionTests : AssertionTests
+    {
+        [Test]
+        public async Task TaskShouldThrowType_ThrowsCorrectType_ReturnsException()
+        {
+            Exception expectedException = new Exception();
+            AsyncExceptionThrower thrower = new AsyncExceptionThrower(expectedException);
+
+            ActualException<Exception> result = await Should.Throw<Exception>(() => thrower.Throw());
+
+            Assert.AreSame(expectedException, result.And);
+        }
+
+        [Test]
+        public void TaskShouldThrowType_DoesNotThrow_FailsWithNoExceptionMessage()
+        {
+            Expression<Func<Task>> noThrow = () => Task.FromResult("".Trim());
+            MockFormatter.NoException(typeof(Exception), noThrow, "foo").Returns("bar");
+
+            EasyAssertionException result = Assert.ThrowsAsync<EasyAssertionException>(async () =>
+                await Should.Throw<Exception>(noThrow, "foo"));
+
+            Assert.AreEqual("bar", result.Message);
+        }
+
+        [Test]
+        public void TaskShouldThrowType_ThrowsWrongType_FailsWithWrongExceptionMessage()
+        {
+            AsyncExceptionThrower thrower = new AsyncExceptionThrower(new Exception());
+            Expression<Func<Task>> throwsException = () => thrower.Throw();
+            MockFormatter.WrongException(typeof(InvalidOperationException), typeof(Exception), throwsException, "foo").Returns("bar");
+
+            EasyAssertionException result = Assert.ThrowsAsync<EasyAssertionException>(async () =>
+                await Should.Throw<InvalidOperationException>(throwsException, "foo"));
+
+            Assert.AreEqual("bar", result.Message);
+        }
+
+        [Test]
+        public void TaskShouldThrowType_ThrowsWrongType_FailsWithActualExceptionAsInnerException()
+        {
+            Exception expectedException = new Exception();
+            AsyncExceptionThrower thrower = new AsyncExceptionThrower(expectedException);
+
+            EasyAssertionException result = Assert.ThrowsAsync<EasyAssertionException>(async () =>
+                await Should.Throw<InvalidOperationException>(() => thrower.Throw()));
+
+            Assert.AreSame(expectedException, result.InnerException);
+        }
+
+        [Test]
+        public async Task TaskShouldThrow_Throws_ReturnsException()
+        {
+            Exception expectedExeption = new Exception();
+            AsyncExceptionThrower thrower = new AsyncExceptionThrower(expectedExeption);
+
+            ActualException<Exception> result = await Should.Throw(() => thrower.Throw());
+
+            Assert.AreSame(expectedExeption, result.And);
+        }
+
+        [Test]
+        public void TaskShouldThrow_DoesNotThrow_FailsWithNoExceptionMessage()
+        {
+            Expression<Func<Task>> noThrow = () => Task.FromResult("".Length);
+            MockFormatter.NoException(typeof(Exception), noThrow, "foo").Returns("bar");
+
+            EasyAssertionException result = Assert.ThrowsAsync<EasyAssertionException>(async () =>
+                await Should.Throw(noThrow, "foo"));
+
+            Assert.AreEqual("bar", result.Message);
+        }
+
+        private class AsyncExceptionThrower
+        {
+            private readonly Exception _exception;
+
+            public AsyncExceptionThrower(Exception exception)
+            {
+                _exception = exception;
+            }
+
+            public async Task Throw()
+            {
+                await Task.Yield(); // Forces the exception to be thrown in a continuation
+                throw _exception;
+            }
+        }
+    }
+}

--- a/UnitTests/UnitTests.csproj
+++ b/UnitTests/UnitTests.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>EasyAssertions.UnitTests</RootNamespace>
     <AssemblyName>EasyAssertions.UnitTests</AssemblyName>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
@@ -32,6 +32,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -40,6 +41,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup>
     <SignAssembly>true</SignAssembly>
@@ -52,8 +54,9 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\NSubstitute.1.4.2.0\lib\NET35\NSubstitute.dll</HintPath>
     </Reference>
-    <Reference Include="nunit.framework">
-      <HintPath>..\packages\NUnit.2.6.0.12054\lib\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.6.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.6.0\lib\net45\nunit.framework.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="SmartFormat">
       <HintPath>..\lib\SmartFormat.dll</HintPath>
@@ -64,6 +67,7 @@
   <ItemGroup>
     <Compile Include="ActualExceptionTests.cs" />
     <Compile Include="AssertionMethodTests.cs" />
+    <Compile Include="Assertions\AsyncFunctionAssertionTests.cs" />
     <Compile Include="Assertions\CollectionAssertionTests.cs" />
     <Compile Include="Assertions\AssertionTests.cs" />
     <Compile Include="Assertions\EasyAssertionTests.cs" />

--- a/UnitTests/packages.config
+++ b/UnitTests/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NSubstitute" version="1.4.2.0" targetFramework="net35" />
-  <package id="NUnit" version="2.6.0.12054" />
+  <package id="NSubstitute" version="1.4.2.0" targetFramework="net35" requireReinstallation="true" />
+  <package id="NUnit" version="3.6.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
 - Updated the framework version to 4.5 so that tasks and async/await can be used
 - Updated NUnit to take advantage of Task.ThrowsAsync in tests.